### PR TITLE
replace_squaremask: `show_mask` param

### DIFF
--- a/vsmasktools/utils.py
+++ b/vsmasktools/utils.py
@@ -127,13 +127,13 @@ def replace_squaremask(
 
     mask = squaremask(clipb[0], *mask_params, invert, func)
 
-    if show_mask:
-        return mask
-
     if isinstance(blur_sigma, int):
         mask = box_blur(mask, blur_sigma)
     elif isinstance(blur_sigma, float):
         mask = gauss_blur(mask, blur_sigma)
+
+    if show_mask:
+        return mask.std.Loop(clipa.num_frames)
 
     merge = clipa.std.MaskedMerge(clipb, mask.std.Loop(clipa.num_frames))
 

--- a/vsmasktools/utils.py
+++ b/vsmasktools/utils.py
@@ -119,13 +119,16 @@ def squaremask(
 def replace_squaremask(
     clipa: vs.VideoNode, clipb: vs.VideoNode, mask_params: tuple[int, int, int, int],
     ranges: FrameRangeN | FrameRangesN | None = None, blur_sigma: int | float | None = None,
-    invert: bool = False, func: FuncExceptT | None = None
+    invert: bool = False, func: FuncExceptT | None = None, show_mask: bool = False
 ) -> vs.VideoNode:
     func = func or replace_squaremask
 
     assert check_variable(clipa, func) and check_variable(clipb, func)
 
     mask = squaremask(clipb[0], *mask_params, invert, func)
+
+    if show_mask:
+        return mask
 
     if isinstance(blur_sigma, int):
         mask = box_blur(mask, blur_sigma)

--- a/vsmasktools/utils.py
+++ b/vsmasktools/utils.py
@@ -132,10 +132,12 @@ def replace_squaremask(
     elif isinstance(blur_sigma, float):
         mask = gauss_blur(mask, blur_sigma)
 
-    if show_mask:
-        return mask.std.Loop(clipa.num_frames)
+    mask = mask.std.Loop(clipa.num_frames)
 
-    merge = clipa.std.MaskedMerge(clipb, mask.std.Loop(clipa.num_frames))
+    if show_mask:
+        return mask
+
+    merge = clipa.std.MaskedMerge(clipb, mask)
 
     return replace_ranges(clipa, merge, ranges)
 


### PR DESCRIPTION
Add a `show_mask` param so users who want to use `replace_squaremask` are not forced to call `squaremask` separately just to check the mask.