### PR TITLE
Fix MagDirection assertion on Python 3.10

### DIFF
--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -55,7 +55,7 @@ class MagDirection(IntFlag):
     SOUTH = S | SW | SE
 
     def select_matrices(self, matrices: Sequence[T]) -> Sequence[T]:
-        assert len(matrices) == len(MagDirection) and self
+        assert len(matrices) == 8 and self
 
         return [
             matrix for flag, matrix in zip(MagDirection, matrices) if self & flag


### PR DESCRIPTION
Python 3.10 and Python 3.11 differ on how they define `len` of an enum. The behavior in 3.11 matches what we desire, but the behavior in 3.10 does not.

I don't know of the proper method dynamic method to use for this, so this fix takes the shortcut of comparing to the known number of directions (8) instead, which will work on all versions of Python.