### PR TITLE
Fix MagDirection.*.select_matrices for older Python versions.

### DIFF
--- a/vsmasktools/edge/_abstract.py
+++ b/vsmasktools/edge/_abstract.py
@@ -55,10 +55,15 @@ class MagDirection(IntFlag):
     SOUTH = S | SW | SE
 
     def select_matrices(self, matrices: Sequence[T]) -> Sequence[T]:
-        assert len(matrices) == len(MagDirection) and self
+        # In Python <3.11, composite flags are included in MagDirection's
+        # collection and iteration interfaces.
+        primary_flags = [
+            flag for flag in MagDirection if flag != 0 and flag & (flag - 1) == 0
+        ]
+        assert len(matrices) == len(primary_flags) and self
 
         return [
-            matrix for flag, matrix in zip(MagDirection, matrices) if self & flag
+            matrix for flag, matrix in zip(primary_flags, matrices) if self & flag
         ]
 
 


### PR DESCRIPTION
Older Python considers an `Enum`'s composite `Flag`s to be canonical, but those flags are noise to the matrix-matching process.  This change filters out the composite flags using the same math that Python 3.11 does.

This is an alternative to Irrational-Encoding-Wizardry/vs-masktools#11 that avoids hardcoding per @Setsugennoao's preference.